### PR TITLE
Feature: add option for alternate shell icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ set -g window-status-current-format '#[fg=magenta]#W'
 set -g window-status-format         '#[fg=gray]#W'
 ```
 
+### Alternate shell icon
+
+To show a reverse white-on-black NerdFont icon for shells, set the following:
+
+```sh
+set -g @tmux-nerd-font-window-name-alterate-shell-icon true
+```
 ## How it works
 
 When installed, your window names will automatically update to a Nerd Font that matches the activity (ex: vim, bash, node, ect...).

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ set -g window-status-current-format '#[fg=magenta]#W'
 set -g window-status-format         '#[fg=gray]#W'
 ```
 
-### Alternate shell icon
+### Custom shell icon
 
-To show a reverse white-on-black NerdFont icon for shells, set the following:
+To specify a custom shell icon, use the following option to set any icon you prefer:
 
 ```sh
-set -g @tmux-nerd-font-window-name-alterate-shell-icon true
+set -g @tmux-nerd-font-window-name-shell-icon ""
 ```
 ## How it works
 

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -2,13 +2,20 @@
 
 NAME=$1
 
-# Use reverse shell icon if option is true
-ALTERNATE_SHELL_ICON="$(tmux show -gqv '@tmux-nerd-font-window-name-alterate-shell-icon')"
-SHELL_ICON=""
+# Get shell icon, using user-provided option if available
+function get_shell_icon(){
+  local default_shell_icon=""
+  local shell_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-shell-icon')"
 
-if [ "$ALTERNATE_SHELL_ICON" = true ]; then
-	SHELL_ICON=""
-fi
+  # Alternate shell icon is nonempty
+  if [ -n "$shell_icon" ]; then
+    echo "$shell_icon"
+  else
+    echo "$default_shell_icon"
+  fi
+}
+
+SHELL_ICON=$(get_shell_icon)
 
 get_icon() {
 	case $NAME in

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -2,13 +2,21 @@
 
 NAME=$1
 
+# Use reverse shell icon if option is true
+ALTERNATE_SHELL_ICON="$(tmux show -gqv '@tmux-nerd-font-window-name-alterate-shell-icon')"
+SHELL_ICON=""
+
+if [ "$ALTERNATE_SHELL_ICON" = true ]; then
+	SHELL_ICON=""
+fi
+
 get_icon() {
 	case $NAME in
 	tmux)
 		echo ""
 		;;
 	fish | zsh | bash | tcsh)
-		echo ""
+		echo $SHELL_ICON
 		;;
 	vi | vim | nvim | lvim)
 		echo ""


### PR DESCRIPTION
## Alternate Shell Icon Feature

For some odd reason, the NerdFont icon `nf-dev-terminal` renders strangely when windows running shells are focused. It could be Kitty, it could be my theme; I've tried several different NerdFont options to no avail. Not sure what the problem is or if it's repeatable. I've added an option to change this icon from black-on-white to white-on-black, which renders correctly and looks quite a bit better on my machine, regardless of the weird focus problem.

I'm also thinking about adding a small preview for the icon difference in the README but I'm not sure if that's necessary. Please advise!

### Demo:

![icon-behavior](https://user-images.githubusercontent.com/8506829/227315173-c035e06b-e90f-40f7-8c35-d814de2e0dc7.gif)

### Detail:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/8506829/227316084-8314e1d7-7680-44b5-97ee-a8248808875e.png">