### PR TITLE
fix: update icons to new version of nerdfonts

### DIFF
--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -4,70 +4,70 @@ NAME=$1
 SHOW_NAME="$(tmux show -gqv '@tmux-nerd-font-window-name-show-name')"
 
 function get_shell_icon() {
-	local default_shell_icon=""
-	local shell_icon
-	shell_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-shell-icon')"
-	if [ -n "$shell_icon" ]; then
-		echo "$shell_icon"
-	else
-		echo "$default_shell_icon"
-	fi
+  local default_shell_icon=""
+  local shell_icon
+  shell_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-shell-icon')"
+  if [ "$shell_icon" != "" ]; then
+    echo "$shell_icon"
+  else
+    echo "$default_shell_icon"
+  fi
 }
 
 SHELL_ICON=$(get_shell_icon)
 
 get_icon() {
-	case $NAME in
-	tmux)
-		echo ""
-		;;
-	htop | top)
-		echo ""
-		;;
-	fish | zsh | bash | tcsh)
-		echo "$SHELL_ICON"
-		;;
-	vi | vim | nvim | lvim)
-		echo ""
-		;;
-	lazygit | git | tig)
-		echo ""
-		;;
-	node)
-		echo ""
-		;;
-	ruby)
-		echo ""
-		;;
-	go)
-		echo "ﳑ"
-		;;
-	lf | lfcd)
-		echo ""
-		;;
-	beam | beam.smp) # Erlang runtime
-		echo ""
-		;;
-	rustc | rustup)
-		echo ""
-		;;
-	Python)
-		echo ""
-		;;
-	*)
-		if [ "$SHOW_NAME" = true ]; then
-			echo ""
-		else
-			echo "$NAME"
-		fi
-		;;
-	esac
+  case $NAME in
+  tmux)
+    echo ""
+    ;;
+  htop | top)
+    echo ""
+    ;;
+  fish | zsh | bash | tcsh)
+    echo "$SHELL_ICON"
+    ;;
+  vi | vim | nvim | lvim)
+    echo ""
+    ;;
+  lazygit | git | tig)
+    echo ""
+    ;;
+  node)
+    echo "󰎙"
+    ;;
+  ruby)
+    echo ""
+    ;;
+  go)
+    echo ""
+    ;;
+  lf | lfcd)
+    echo ""
+    ;;
+  beam | beam.smp) # Erlang runtime
+    echo ""
+    ;;
+  rustc | rustup)
+    echo ""
+    ;;
+  Python)
+    echo ""
+    ;;
+  *)
+    if [ "$SHOW_NAME" = true ]; then
+      echo ""
+    else
+      echo "$NAME"
+    fi
+    ;;
+  esac
 }
 
 ICON=$(get_icon)
 
 if [ "$SHOW_NAME" = true ]; then
-	echo "$ICON" "$NAME"
+  echo "$ICON" "$NAME"
 else
-	echo "$ICON"
+  echo "$ICON"
 fi


### PR DESCRIPTION
Some of the icons used has been removed in current version of nerdfonts. Icons have been changed to new ones. 

Affects to the node and go icon. 