### PR TITLE
Added extra icon options for editors, git, music players and unknown programs, and added more icons for programs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ set -g @tmux-nerd-font-window-name-shell-icon "" # Shell
 set -g @tmux-nerd-font-window-name-music-icon "󰝚" # Music
 set -g @tmux-nerd-font-window-name-editor-icon "󰨞" # Editor
 set -g @tmux-nerd-font-window-name-editor-enable-all true # Apply to all editors (above setting only applies to editors that are not Vim or Emacs)
-set -g @tmux-nerd-font-window-name-fallback-icon "󰒓" # Unknown program
+set -g @tmux-nerd-font-window-name-git-icon "" # Git
+set -g @tmux-nerd-font-window-name-fallback-icon "󰒓" # Unknown programs
 ```
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ set -g window-status-current-format '#[fg=magenta]#W'
 set -g window-status-format         '#[fg=gray]#W'
 ```
 
-### Custom shell icon
+### Customize icons
 
-To specify a custom shell icon, use the following option to set any icon you prefer:
+To specify a custom icon for your editor, music player, shell, and for unknown programs, use the following option to set any icon you prefer:
 
 ```sh
-set -g @tmux-nerd-font-window-name-shell-icon ""
+set -g @tmux-nerd-font-window-name-shell-icon "" # Shell
+set -g @tmux-nerd-font-window-name-music-icon "󰝚" # Music
+set -g @tmux-nerd-font-window-name-editor-icon "󰨞" # Editor
+set -g @tmux-nerd-font-window-name-editor-enable-all true # Apply to all editors (above setting only applies to editors that are not Vim or Emacs)
+set -g @tmux-nerd-font-window-name-fallback-icon "󰒓" # Unknown program
 ```
 ## How it works
 

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -2,6 +2,7 @@
 
 NAME=$1
 SHOW_NAME="$(tmux show -gqv '@tmux-nerd-font-window-name-show-name')"
+ALL_EDITORS="$(tmux show -gqv '@tmux-nerd-font-window-name-editor-enable-all')"
 
 function get_shell_icon() {
 	local default_shell_icon=""
@@ -13,7 +14,6 @@ function get_shell_icon() {
 		echo "$default_shell_icon"
 	fi
 }
-
 function get_music_icon() {
 	local default_music_icon=""
 	local music_icon
@@ -24,8 +24,31 @@ function get_music_icon() {
 		echo "$default_music_icon"
 	fi
 }
+function get_editor_icon() {
+	local default_editor_icon="󱇨"
+	local editor_icon
+	editor_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-editor-icon')"
+	if [ "$editor_icon" != "" ]; then
+		echo "$editor_icon"
+	else
+		echo "$default_editor_icon"
+	fi
+}
+function get_fallback_icon() {
+	local default_fallback_icon=""
+	local fallback_icon
+	fallback_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-fallback-icon')"
+	if [ "$fallback_icon" != "" ]; then
+		echo "$fallback_icon"
+	else
+		echo "$default_fallback_icon"
+	fi
+}
+
 SHELL_ICON=$(get_shell_icon)
 MUSIC_ICON=$(get_music_icon)
+EDITOR_ICON=$(get_editor_icon)
+FALLBACK_ICON=$(get_fallback_icon)
 
 get_icon() {
 	case $NAME in
@@ -38,13 +61,21 @@ get_icon() {
 
 	### Editors ###
 	vi | vim | nvim | lvim)
-		echo ""
+		if [ "$ALL_EDITORS" = true ]; then
+    	echo "$EDITOR_ICON"
+    else
+			echo ""
+    fi
 		;;
 	hx | kak)
-		echo ""
+		echo "$EDITOR_ICON"
 		;;
 	emacs)
-		echo ""
+		if [ "$ALL_EDITORS" = true ]; then
+    	echo "$EDITOR_ICON"
+    else
+			echo ""
+    fi
 		;;
 	lazygit | git | tig)
 		echo ""
@@ -86,7 +117,7 @@ get_icon() {
 		;;
 	*)
 		if [ "$SHOW_NAME" = true ]; then
-			echo ""
+			echo "$FALLBACK_ICON"
 		else
 			echo "$NAME"
 		fi

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -96,6 +96,9 @@ get_icon() {
 	lf | lfcd | ranger)
 		echo ""
 		;;
+	fzf | sk)
+		echo "󱈅"
+		;;
 	lazygit | git | tig | gitui)
 		echo "$GIT_ICON"
 		;;

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -73,17 +73,17 @@ get_icon() {
 	### Editors ###
 	vi | vim | nvim | lvim)
 		if [ "$ALL_EDITORS" = true ]; then
-    	echo "$EDITOR_ICON"
-    else
+			echo "$EDITOR_ICON"
+		else
 			echo ""
-    fi
+		fi
 		;;
 	emacs)
 		if [ "$ALL_EDITORS" = true ]; then
-    	echo "$EDITOR_ICON"
-    else
+				echo "$EDITOR_ICON"
+		else
 			echo ""
-    fi
+		fi
 		;;
 	hx | kak | ne | mcedit | nano | micro)
 		echo "$EDITOR_ICON"

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -14,25 +14,54 @@ function get_shell_icon() {
 	fi
 }
 
+function get_music_icon() {
+	local default_music_icon=""
+	local music_icon
+	music_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-music-icon')"
+	if [ "$music_icon" != "" ]; then
+		echo "$music_icon"
+	else
+		echo "$default_music_icon"
+	fi
+}
 SHELL_ICON=$(get_shell_icon)
+MUSIC_ICON=$(get_music_icon)
 
 get_icon() {
 	case $NAME in
 	tmux)
 		echo ""
 		;;
-	htop | top)
-		echo ""
-		;;
 	fish | zsh | bash | tcsh)
 		echo "$SHELL_ICON"
 		;;
+
+	### Editors ###
 	vi | vim | nvim | lvim)
 		echo ""
+		;;
+	hx | kak)
+		echo ""
+		;;
+	emacs)
+		echo ""
 		;;
 	lazygit | git | tig)
 		echo ""
 		;;
+
+	### Utlities ###
+	lf | lfcd | ranger)
+		echo ""
+		;;
+	htop | top | btop | btm)
+		echo ""
+		;;
+	cmus | ncmpcpp)
+		echo "$MUSIC_ICON"
+		;;
+
+	### Languages ###
 	node)
 		echo ""
 		;;
@@ -42,14 +71,15 @@ get_icon() {
 	go)
 		echo ""
 		;;
-	lf | lfcd)
-		echo ""
-		;;
 	beam | beam.smp) # Erlang runtime
 		echo ""
 		;;
-	rustc | rustup)
+	rustc | rustup | cargo)
 		echo ""
+		;;
+	# TODO: Maybe find a way to make this line less long?
+	nix | nix-build | nix-collect-garbage | nix-copy-closure | nix-env | nix-info | nix-instantiate | nix-locate | nixos-build-vms | nixos-container | nixos-enter | nixos-rebuild | nix-shell)
+		echo "󱄅"
 		;;
 	Python)
 		echo ""

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -34,6 +34,16 @@ function get_editor_icon() {
 		echo "$default_editor_icon"
 	fi
 }
+function get_git_icon() {
+	local default_git_icon="󰊢"
+	local git_icon
+	git_icon="$(tmux show -gqv '@tmux-nerd-font-window-name-git-icon')"
+	if [ "$git_icon" != "" ]; then
+		echo "$git_icon"
+	else
+		echo "$default_git_icon"
+	fi
+}
 function get_fallback_icon() {
 	local default_fallback_icon=""
 	local fallback_icon
@@ -48,6 +58,7 @@ function get_fallback_icon() {
 SHELL_ICON=$(get_shell_icon)
 MUSIC_ICON=$(get_music_icon)
 EDITOR_ICON=$(get_editor_icon)
+GIT_ICON=$(get_git_icon)
 FALLBACK_ICON=$(get_fallback_icon)
 
 get_icon() {
@@ -55,7 +66,7 @@ get_icon() {
 	tmux)
 		echo ""
 		;;
-	fish | zsh | bash | tcsh)
+	fish | zsh | bash | tcsh | xonsh | nu)
 		echo "$SHELL_ICON"
 		;;
 
@@ -67,9 +78,6 @@ get_icon() {
 			echo ""
     fi
 		;;
-	hx | kak)
-		echo "$EDITOR_ICON"
-		;;
 	emacs)
 		if [ "$ALL_EDITORS" = true ]; then
     	echo "$EDITOR_ICON"
@@ -77,19 +85,48 @@ get_icon() {
 			echo ""
     fi
 		;;
-	lazygit | git | tig)
-		echo ""
+	hx | kak | ne | mcedit | nano | micro)
+		echo "$EDITOR_ICON"
 		;;
 
 	### Utlities ###
+	ssh | mosh)
+		echo ""
+		;;
 	lf | lfcd | ranger)
 		echo ""
+		;;
+	lazygit | git | tig | gitui)
+		echo "$GIT_ICON"
 		;;
 	htop | top | btop | btm)
 		echo ""
 		;;
+	cfdisk | fdisk | parted)
+		echo ""
+		;;
 	cmus | ncmpcpp)
 		echo "$MUSIC_ICON"
+		;;
+	yt-dlp | youtube-dl)
+		echo "󰗃"
+		;;
+
+	### Package Managers ###
+	apt | nala | dpkg)
+		echo ""
+		;;
+	dnf | yum)
+		echo ""
+		;;
+	pacman | yay | paru)
+		echo ""
+		;;
+	emerge)
+		echo ""
+		;;
+	brew)
+		echo "󰂘"
 		;;
 
 	### Languages ###
@@ -97,10 +134,13 @@ get_icon() {
 		echo ""
 		;;
 	ruby)
-		echo ""
+		echo ""
 		;;
 	go)
-		echo ""
+		echo "󰟓"
+		;;
+	clang | gcc | g++)
+		echo "󰙱"
 		;;
 	beam | beam.smp) # Erlang runtime
 		echo ""


### PR DESCRIPTION
Added options for:

- Text editors (icon and option to force icon setting to all text editors since Vim and Emacs are ignored by default)
- Git and git clients (icon)
- Music players (cmus and ncmpcpp icon)
- Unknown apps (ability to replace ? icon)

Added icons for:

- Shells: xonsh and nushell
- Editors: emacs, helix, nice editor, mcedit, nano, micro
- SSH: ssh and mosh
- File Manager: ranger
- Git: gitui
- Process managers: btop and bottom
- Disk utility: cfdisk, fdisk and parted
- Music players: cmus and ncmpcpp
- Youtube downloaders: yt-dlp and youtube-dl
- Fuzzy finders: fzf and skim
- Package managers: apt, nala, dpkg, dnf, yum, pacman, yay, paru, emerge, brew and nix
- C and C++ compilers: gcc, clang and g++

Other information:

- Replaced icons for go and ruby (to make it more recognizable)
- Added cargo to rust icon (part of rust toolchain)
- Nix is labeled as a language (as it is both a package manager and a language at the same time)
- Organized the `get_icon` function with categories
- Vim and Emacs have their own icons unless overwritten with the `tmux-nerd-font-window-name-editor-enable-all` option set to true.
- Changed README for new options
- Tested programs with nix-shell on NixOS 23.05