### PR TITLE
Add icons for caffeinate/java/kubectl

### DIFF
--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -6,6 +6,7 @@ config:
 icons:
   apt: ""
   bash: ""
+  caffeinate: ""
   beam.smp: ""
   beam: ""
   brew: ""

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -22,6 +22,7 @@ icons:
   go: ""
   htop: ""
   java: ""
+  kubectl: "󱃾"
   lazydocker: ""
   lazygit: ""
   lf: ""

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -20,6 +20,7 @@ icons:
   gitui: ""
   go: ""
   htop: ""
+  java: ""
   lazydocker: ""
   lazygit: ""
   lf: ""


### PR DESCRIPTION
Changes:

1. feat: add nf-fae-java as icon for java
2. feat: add nf-fa-coffee as icon for caffeinate
3. feat: add nf-md-kubernetes as icon for kubectl

Comments:
Re 1) I favoured `nf-fae-java` over `nf-dev-java` and `nf-md-language_java` since it renders the biggest of the three
Re 2) caffeinate is macOS specific. A helper to prevent the Mac from going to sleep, see also https://www.theapplegeek.co.uk/blog/caffeinate#:~:text=Caffeinate%20is%20a%20terminal%2Dbased,ve%20plugged%20the%20MacBook%20in.

