### PR TITLE
use lowercase name for icon lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ config:
   fallback-icon: "?" # icon to use if no definition is found
   multi-pane-icon: "" # icon to use for window with multiple panes, if not specified, only active pane's icon will used as the default.
   show-name: true # show the window name with the icon
+  downcase-name: false # downcase the window name before icon lookup
 
 icons:
   zsh: "" # overwrite with your own symbol (Nerd Font icon, emoji, whatever!)

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -20,8 +20,14 @@ get_config_value() {
 	echo "$value"
 }
 
-LOWERCASE_NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
-ICON="$(get_config_value ".icons.$LOWERCASE_NAME")"
+ICON_NAME="$NAME"
+
+DOWNCASE_NAME="$(get_config_value '.config.downcase-name')"
+if [ "$DOWNCASE_NAME" = true ]; then
+	ICON_NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
+fi
+
+ICON="$(get_config_value ".icons.$ICON_NAME")"
 
 if [ "$ICON" == "null" ]; then
 	FALLBACK_ICON="$(get_config_value '.config.fallback-icon')"

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -20,7 +20,8 @@ get_config_value() {
 	echo "$value"
 }
 
-ICON="$(get_config_value ".icons.$NAME")"
+LOWERCASE_NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
+ICON="$(get_config_value ".icons.$LOWERCASE_NAME")"
 
 if [ "$ICON" == "null" ]; then
 	FALLBACK_ICON="$(get_config_value '.config.fallback-icon')"


### PR DESCRIPTION
got a pane_current_command like `Emacs` in my terminal environment, convert it to a lower string for icon lookup.
