### PR TITLE
quote command name to support command with special characters in it

### DIFF
--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -20,7 +20,7 @@ get_config_value() {
 	echo "$value"
 }
 
-ICON="$(get_config_value ".icons.$NAME")"
+ICON="$(get_config_value ".icons.\"$NAME\"")"
 
 if [ "$ICON" == "null" ]; then
 	FALLBACK_ICON="$(get_config_value '.config.fallback-icon')"


### PR DESCRIPTION
make it work even special characters in command name like `emacs-29.1`.

https://mikefarah.gitbook.io/yq/operators/traverse-read#special-characters

