### PR TITLE
Icon position config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ config:
   fallback-icon: "?" # show when no definition is found
   multi-pane-icon: "" # show when window has multiple panes (blank by default)
   show-name: true # show the window name with the icon (defaults to false)
+  icon-position: "left" # show the icon to the "left" or "right" of the window name (defaults to left)
 
 icons:
   zsh: "" # overwrite with your own symbol (Nerd Font icon, emoji, whatever!)

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -36,7 +36,12 @@ fi
 
 SHOW_NAME="$(get_config_value '.config.show-name')"
 if [ "$SHOW_NAME" = true ]; then
-	ICON="$ICON $NAME"
+	ICON_POSITION="$(get_config_value '.config.icon-position')"
+	if [ "$ICON_POSITION" == "right" ]; then
+		ICON="$NAME $ICON"
+	else
+		ICON="$ICON $NAME"
+	fi
 fi
 
 echo "$ICON"


### PR DESCRIPTION
Closes #29 

Adds a new config feature flag for positioning the icon to the window name.

```yml
config:
  show-name: true # must be true for `icon-position` to work
  icon-position: "left" # show the icon to the "left" or "right" of the window name (defaults to left)
```
