### PR TITLE
feat: show simple error message if yq is missing

### DIFF
--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if ! command -v yq >/dev/null 2>&1; then
+	echo "$1 ⚠︎ yq missing"
+	exit 1
+fi
+
 NAME="$1"
 PANES="$2"
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Closes #36 

Displays "⚠︎ yq missing" after the window name if yq isn't installed.

![SCR-20240326-iivb](https://github.com/joshmedeski/tmux-nerd-font-window-name/assets/2036594/a91bfeb5-e181-4bef-a789-c244271e5b26)