### PR TITLE
fix: add yq prior to 4.18.* support

### DIFF
--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -5,6 +5,12 @@ if ! command -v yq >/dev/null 2>&1; then
 	exit 1
 fi
 
+EVAL=""
+version="$(yq --version | sed 's/.*[[:digit:]].\([[:digit:]]\).[[:digit:]]/\1/')"
+if (($version < 18)); then
+  EVAL="eval"
+fi
+
 NAME="$1"
 PANES="$2"
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,12 +21,12 @@ get_config_value() {
 	local key=$1
 	local value
 	if test -f "$USER_CONFIG"; then
-		value="$(yq "$key" "$USER_CONFIG")"
+		value="$(yq $EVAL "$key" "$USER_CONFIG")"
 		if [ "$value" == "null" ]; then # get default config value
-			value="$(yq "$key" "$DEFAULT_CONFIG")"
+			value="$(yq $EVAL "$key" "$DEFAULT_CONFIG")"
 		fi
 	else
-		value="$(yq "$key" "$DEFAULT_CONFIG")"
+		value="$(yq $EVAL "$key" "$DEFAULT_CONFIG")"
 	fi
 	echo "$value"
 }


### PR DESCRIPTION
Hi, thank you for your wonderful plugin!

I've tried to install it on my machine and received the following error message:
```
Error: unknown command ".icons.\"vim\"" for "yq"
Run 'yq --help' for usage.
bash: [: bin/defaults.yml: integer expression expected
Error: unknown command ".config.show-name" for "yq"
Run 'yq --help' for usage.
```

The source of the issue was that `yq` on my system has 4.2.0 version and according to this discussion https://github.com/mikefarah/yq/issues/1158#issuecomment-1081245199 prior to 4.18.x `eval` word must be specified before the actual commands.

I've added a check of the `yq` version and inserted `eval` if it's actually required.