### PR TITLE
Add 3 new process icons

### DIFF
--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -36,6 +36,7 @@ icons:
   lf: ""
   lfcd: ""
   lvim: ""
+  mactop: ""
   nala: ""
   node: ""
   nu: ""

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -11,6 +11,7 @@ icons:
   beam.smp: ""
   beam: ""
   brew: ""
+  btop: ""
   cfdisk: ""
   dnf: ""
   docker: ""

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -21,6 +21,7 @@ icons:
   git: ""
   gitui: ""
   gh: ""
+  ghostty: ""
   go: ""
   helm: "󱃾"
   hx: "󰔤"


### PR DESCRIPTION
- btop, mactop: using the pre-existing logo for other tops. (although given it's hard to read I do wonder if this is a better alternative top system monitors? `` (\xEF\x84\x8A)
- ghostty: this comes up when you run builtin ghostty terminal commands such as 'ghostty +list-themes'