### PR TITLE
python instead of Python

### DIFF
--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -44,7 +44,7 @@ icons:
   pacman: ""
   parted: ""
   paru: ""
-  Python: ""
+  python: ""
   ranger: ""
   ruby: ""
   rustc: ""


### PR DESCRIPTION
When running python, the command is "python", not "Python". This will substitute the current "? python" window name with "{python icon} python"