### PR TITLE
feat: add bazel, glances and kubie icons

### DIFF
--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -33,6 +33,7 @@ icons:
   just: ""
   k9s: "󱃾"
   kubectl: "󱃾"
+  kubie: "󱃾"
   lazydocker: ""
   lazygit: ""
   lf: ""

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -28,6 +28,7 @@ icons:
   helm: "󱃾"
   hx: "󰔤"
   htop: ""
+  glances: ""
   java: ""
   just: ""
   k9s: "󱃾"

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -6,6 +6,7 @@ config:
 icons:
   apt: ""
   bash: ""
+  bazel: ""
   caffeinate: ""
   cargo: ""
   beam.smp: ""


### PR DESCRIPTION
Add icons for [bazel](https://bazel.build/), [kubie](https://github.com/sbstp/kubie) and [glances](https://github.com/nicolargo/glances). Bazel comes from [nerdfonts](https://www.nerdfonts.com/cheat-sheet?q=bazel), for kubie I re-used the kubernetes one and for glances the same as for other top system monitors.