### PR TITLE
feat: allow placeholder replace over custom format

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ icons:
   cmatrix: "🤯" # add new entries that aren't included
 ```
 
+### Custom Placeholder Support
+
+If you prefer to define your own `automatic-rename-format`,
+you can include a placeholder that lets this plugin inject its icon output.
+
+For example:
+
+```tmux
+set -g automatic-rename-format "#{window_icon} #{pane_current_command}"
+```
+
 ## Contributions
 
 Contributions are welcome! Feel free to make a pull request to submit more

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ you can include a placeholder that lets this plugin inject its icon output.
 For example:
 
 ```tmux
-set -g automatic-rename-format "#{window_icon} #{pane_current_command}"
+set -g automatic-rename-format "#{window_icon} #{b:pane_current_path}"
 ```
 
 ## Contributions

--- a/tmux-nerd-font-window-name.tmux
+++ b/tmux-nerd-font-window-name.tmux
@@ -6,7 +6,7 @@ plugin_format="#($CURRENT_DIR/bin/tmux-nerd-font-window-name #{pane_current_comm
 user_format="$(tmux show-option -gv automatic-rename-format 2>/dev/null)"
 placeholder="#{window_icon}"
 
-if [[ "$user_format" == *"$placeholder"* ]]; then
+if [[ -n "$user_format" && "$user_format" == *"$placeholder"* ]]; then
     new_format="${user_format//$placeholder/$plugin_format}"
 else
     new_format="$plugin_format"

--- a/tmux-nerd-font-window-name.tmux
+++ b/tmux-nerd-font-window-name.tmux
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-tmux set-option -g automatic-rename-format "#($CURRENT_DIR/bin/tmux-nerd-font-window-name #{pane_current_command} #{window_panes})"
+
+plugin_format="#($CURRENT_DIR/bin/tmux-nerd-font-window-name #{pane_current_command} #{window_panes})"
+user_format="$(tmux show-option -gv automatic-rename-format 2>/dev/null)"
+placeholder="#{window_icon}"
+
+if [[ "$user_format" == *"$placeholder"* ]]; then
+    new_format="${user_format//$placeholder/$plugin_format}"
+else
+    new_format="$plugin_format"
+fi
+
+tmux set-option -g automatic-rename-format "$new_format"


### PR DESCRIPTION
Hi, I'm opening up this PR following #41.

While looking at other tmux plugin approaches (for example, [tmux-plugin-sysstat](https://github.com/samoshkin/tmux-plugin-sysstat/tree/master#basic-usage)), I thought a similar idea could improve flexibility here as well.

### Summary
This PR allows users to include a custom placeholder (`#{window_icon}`) in their own `automatic-rename-format`, which will be replaced by the plugin’s dynamic icon output.

### Example
User-defined `.tmux.conf`:

```tmux
set -g automatic-rename-format '#{window_icon}  #{b:pane_current_path}'
```
### Behavior
- If `#{window_icon}` exists → replaced by plugin format
- Otherwise → fallback to plugin’s default behavior