### PR TITLE
Add always-show-fallback-name config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ config:
   fallback-icon: "?" # show when no definition is found
   multi-pane-icon: "" # show when window has multiple panes (blank by default)
   show-name: true # show the window name with the icon (defaults to false)
+  always-show-fallback-name: false # always show the name alongside the fallback icon, even when show-name is false (defaults to false)
   icon-position: "left" # show the icon to the "left" or "right" of the window name (defaults to left)
 
 icons:

--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -2,6 +2,7 @@
 config:
   fallback-icon: "?"
   show-name: true
+  always-show-fallback-name: false
 
 icons:
   alacritty: ""

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -33,8 +33,10 @@ get_config_value() {
 ICON="$(get_config_value ".icons[\"$NAME\"]")"
 
 # Fallback icon if no specific icon is found
+IS_FALLBACK=false
 if [ "$ICON" == "null" ] || [ -z "$ICON" ]; then
   ICON="$(get_config_value '.config["fallback-icon"]')"
+  IS_FALLBACK=true
 fi
 
 # If multiple panes are open, add a multi-pane icon if available
@@ -53,6 +55,16 @@ if [ "$SHOW_NAME" = "true" ]; then
     ICON="$NAME $ICON"
   else
     ICON="$ICON $NAME"
+  fi
+elif [ "$IS_FALLBACK" = "true" ]; then
+  ALWAYS_SHOW_FALLBACK_NAME="$(get_config_value '.config["always-show-fallback-name"]')"
+  if [ "$ALWAYS_SHOW_FALLBACK_NAME" = "true" ]; then
+    ICON_POSITION="$(get_config_value '.config["icon-position"]')"
+    if [ "$ICON_POSITION" == "right" ]; then
+      ICON="$NAME $ICON"
+    else
+      ICON="$ICON $NAME"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Add `always-show-fallback-name` config option that shows the command name alongside the fallback icon even when `show-name` is false
- When `show-name` is false and `always-show-fallback-name` is true, unrecognized commands display as `? command_name` while recognized commands remain icon-only
- Defaults to `false` for backward compatibility

## Test Plan
- [x] Set `show-name: false` and `always-show-fallback-name: true`, verify unrecognized commands show `fallback-icon + name`
- [x] Verify recognized commands still show icon-only with above config
- [x] Verify `icon-position` is respected for fallback name display
- [x] Verify backward compatibility: no behavior change when `always-show-fallback-name` is unset or `false`