### PR TITLE
Optimize execution by generating tmux format at load time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .PHONY: test
 
+SHELL := /bin/bash
+
 test:
-	./lib/bashunit test/ --coverage --coverage-paths bin/tmux-nerd-font-window-name --coverage-report coverage/lcov.info
+	./lib/bashunit test/ --coverage --coverage-paths bin/tmux-nerd-font-window-name,bin/generate-tmux-format --coverage-report coverage/lcov.info

--- a/bin/generate-tmux-format
+++ b/bin/generate-tmux-format
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$CURRENT_DIR/lib.sh"
+
+generate_format() {
+  local user_config="${TMUX_NERD_FONT_USER_CONFIG:-$HOME/.config/tmux/tmux-nerd-font-window-name.yml}"
+
+  # Determine which files to read (defaults first, user config overrides)
+  local files="$DEFAULT_CONFIG"
+  if [ -f "$user_config" ]; then
+    files="$DEFAULT_CONFIG $user_config"
+  fi
+
+  # Get config values
+  local fallback_icon show_name always_fallback icon_position multi_pane_icon
+  fallback_icon="$(get_config_value config fallback-icon "$user_config")"
+  show_name="$(get_config_value config show-name "$user_config")"
+  always_fallback="$(get_config_value config always-show-fallback-name "$user_config")"
+  icon_position="$(get_config_value config icon-position "$user_config")"
+  multi_pane_icon="$(get_config_value config multi-pane-icon "$user_config")"
+
+  # Build the flat tmux format string using awk
+  # Reads icon mappings from both config files (user overrides defaults),
+  # then generates flat #{?#{==:#{pane_current_command},CMD},ICON,} conditionals
+  # (constant nesting depth, avoids tmux FORMAT_LOOP_LIMIT of 100)
+  local format
+  format="$(awk \
+    -v fallback="$fallback_icon" \
+    -v show_name="$show_name" \
+    -v always_fallback="$always_fallback" \
+    -v icon_pos="$icon_position" '
+    /^[^ #]/ { current = $0; sub(/:.*/, "", current) }
+    current == "icons" && /^  [^ #]/ {
+      key = $0; sub(/:.*/, "", key); gsub(/^ +/, "", key)
+      val = $0; sub(/^[^:]*: */, "", val); gsub(/^["'"'"'"]|["'"'"'"]$/, "", val)
+      if (!(key in icons)) {
+        order[n++] = key
+      }
+      icons[key] = val
+    }
+    END {
+      # Escape # in fallback for tmux format safety
+      gsub(/#/, "##", fallback)
+
+      # Build the fallback text
+      if (show_name == "true") {
+        fb = fallback
+      } else if (always_fallback == "true") {
+        if (icon_pos == "right") {
+          fb = "#{pane_current_command} " fallback
+        } else {
+          fb = fallback " #{pane_current_command}"
+        }
+      } else {
+        fb = fallback
+      }
+
+      # Build flat conditional chain: each icon is an independent conditional
+      # with an empty false branch (constant depth of 3-4 per conditional)
+      chain = ""
+      for (i = 0; i < n; i++) {
+        k = order[i]
+        v = icons[k]
+        # Escape # in icon values for tmux format safety
+        gsub(/#/, "##", v)
+        chain = chain "#{?#{==:#{pane_current_command}," k "}," v ",}"
+      }
+
+      # Append fallback wrapper: if chain evaluates to non-empty (a match),
+      # the fallback is suppressed; if empty (no match), fallback is shown
+      result = chain "#{?" chain ",," fb "}"
+
+      # Wrap with name display if show-name is enabled
+      if (show_name == "true") {
+        if (icon_pos == "right") {
+          result = "#{pane_current_command} " result
+        } else {
+          result = result " #{pane_current_command}"
+        }
+      }
+
+      printf "%s", result
+    }
+  ' $files)"
+
+  # Add multi-pane prefix if configured
+  if [ "$multi_pane_icon" != "null" ] && [ -n "$multi_pane_icon" ]; then
+    format="#{?#{>:#{window_panes},1},${multi_pane_icon} ,}${format}"
+  fi
+
+  printf '%s' "$format"
+}
+
+# Run generate_format only when executed directly, not when sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  generate_format "$@"
+fi

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+DEFAULT_CONFIG="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/defaults.yml"
+
+# Allow overriding user config path via tmux option
+USER_CONFIG=$(tmux show-option -gqv @tmux-nerd-font-window-name-config-file)
+USER_CONFIG=${USER_CONFIG:-"$HOME/.config/tmux/tmux-nerd-font-window-name.yml"}
+
+# Parse a value from a flat YAML file (section + key lookup, POSIX awk)
+get_yaml_value() {
+  local section="$1"
+  local key="$2"
+  local file="$3"
+  awk -v section="$section" -v key="$key" '
+    /^[^ #]/ { current = $0; sub(/:.*/, "", current) }
+    current == section {
+      if ($0 ~ "^  " key ":") {
+        val = $0
+        sub(/^[^:]*: */, "", val)
+        gsub(/^["'\''"]|["'\''"]$/, "", val)
+        print val
+        found = 1
+        exit
+      }
+    }
+    END { if (!found) print "null" }
+  ' "$file"
+}
+
+# Function to retrieve a configuration value
+get_config_value() {
+  local section="$1"
+  local key="$2"
+  local config="$3"
+  local value=""
+  if [ -f "$config" ]; then
+    value="$(get_yaml_value "$section" "$key" "$config")"
+    if [ "$value" == "null" ]; then
+      value="$(get_yaml_value "$section" "$key" "$DEFAULT_CONFIG")"
+    fi
+  else
+    value="$(get_yaml_value "$section" "$key" "$DEFAULT_CONFIG")"
+  fi
+  echo "$value"
+}

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -1,49 +1,7 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEFAULT_CONFIG="$CURRENT_DIR/defaults.yml"
-
-# Parse a value from a flat YAML file (section + key lookup, POSIX awk)
-get_yaml_value() {
-  local section="$1"
-  local key="$2"
-  local file="$3"
-  awk -v section="$section" -v key="$key" '
-    /^[^ #]/ { current = $0; sub(/:.*/, "", current) }
-    current == section {
-      if ($0 ~ "^  " key ":") {
-        val = $0
-        sub(/^[^:]*: */, "", val)
-        gsub(/^["'\''"]|["'\''"]$/, "", val)
-        print val
-        found = 1
-        exit
-      }
-    }
-    END { if (!found) print "null" }
-  ' "$file"
-}
-
-# Allow overriding user config path via tmux option
-USER_CONFIG=$(tmux show-option -gqv @tmux-nerd-font-window-name-config-file)
-USER_CONFIG=${USER_CONFIG:-"$HOME/.config/tmux/tmux-nerd-font-window-name.yml"}
-
-# Function to retrieve a configuration value
-get_config_value() {
-  local section="$1"
-  local key="$2"
-  local config="$3"
-  local value=""
-  if [ -f "$config" ]; then
-    value="$(get_yaml_value "$section" "$key" "$config")"
-    if [ "$value" == "null" ]; then
-      value="$(get_yaml_value "$section" "$key" "$DEFAULT_CONFIG")"
-    fi
-  else
-    value="$(get_yaml_value "$section" "$key" "$DEFAULT_CONFIG")"
-  fi
-  echo "$value"
-}
+source "$CURRENT_DIR/lib.sh"
 
 main() {
   local name="$1"

--- a/test/generate_tmux_format_test.sh
+++ b/test/generate_tmux_format_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../bin" && pwd)"
+FORMAT_SCRIPT="$SCRIPT_DIR/generate-tmux-format"
+FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" && pwd)"
+DEFAULTS="$SCRIPT_DIR/defaults.yml"
+
+# Source the scripts to make functions available
+source "$FORMAT_SCRIPT"
+
+# Helper: get expected icon from defaults.yml
+get_default_icon() {
+  get_yaml_value icons "$1" "$DEFAULTS"
+}
+
+set_up() {
+  _ORIGINAL_PATH="$PATH"
+}
+
+tear_down() {
+  PATH="$_ORIGINAL_PATH"
+  unset TMUX_NERD_FONT_USER_CONFIG
+}
+
+# --- Icon-only format (no show-name) ---
+
+function test_format_contains_known_icon_conditional() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  local nvim_icon
+  nvim_icon="$(get_default_icon nvim)"
+  assert_contains "#{?#{==:#{pane_current_command},nvim},$nvim_icon," "$output"
+}
+
+function test_format_no_show_name_has_fallback_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  assert_contains ",?}" "$output"
+}
+
+function test_format_no_show_name_does_not_append_command_name() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  assert_not_contains "} #{pane_current_command}" "$output"
+}
+
+# --- show-name with icon-position ---
+
+function test_format_show_name_left_appends_command_name() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/show-name-left.yml"
+  local output
+  output="$(generate_format)"
+  # Format should end with #{pane_current_command}
+  local suffix
+  suffix="${output: -24}"
+  assert_equals " #{pane_current_command}" "$suffix"
+}
+
+function test_format_show_name_right_prepends_command_name() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/show-name-right.yml"
+  local output
+  output="$(generate_format)"
+  # Format should start with #{pane_current_command}
+  local prefix
+  prefix="${output:0:25}"
+  assert_equals "#{pane_current_command} #" "$prefix"
+}
+
+# --- always-show-fallback-name ---
+
+function test_format_fallback_name_left_includes_name_in_fallback() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/fallback-name.yml"
+  local output
+  output="$(generate_format)"
+  # Fallback should be "? #{pane_current_command}" (icon left, then name)
+  assert_contains "? #{pane_current_command}}" "$output"
+}
+
+function test_format_fallback_name_right_includes_name_in_fallback() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/fallback-name-right.yml"
+  local output
+  output="$(generate_format)"
+  # Fallback should be "#{pane_current_command} ?" (name left, then icon)
+  assert_contains "#{pane_current_command} ?}" "$output"
+}
+
+function test_format_fallback_name_known_icon_has_no_name() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/fallback-name.yml"
+  local output
+  output="$(generate_format)"
+  local nvim_icon
+  nvim_icon="$(get_default_icon nvim)"
+  # Known icon branch should just have the icon, no #{pane_current_command} next to it
+  assert_contains "nvim},$nvim_icon," "$output"
+}
+
+# --- Multi-pane prefix ---
+
+function test_format_multi_pane_prefix() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/multi-pane.yml"
+  local output
+  output="$(generate_format)"
+  assert_contains "#{?#{>:#{window_panes},1},M ,}#{?#{==:" "$output"
+}
+
+function test_format_no_multi_pane_without_config() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  assert_not_contains "#{window_panes}" "$output"
+}
+
+# --- User config overrides ---
+
+function test_format_user_override_replaces_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/override.yml"
+  local output
+  output="$(generate_format)"
+  assert_contains "nvim},CUSTOM," "$output"
+}
+
+function test_format_user_override_replaces_fallback() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/override.yml"
+  local output
+  output="$(generate_format)"
+  assert_contains ",X}" "$output"
+}
+
+# --- Multiple icons present ---
+
+function test_format_contains_bash_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  local bash_icon
+  bash_icon="$(get_default_icon bash)"
+  assert_contains "bash},$bash_icon," "$output"
+}
+
+function test_format_contains_git_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  local git_icon
+  git_icon="$(get_default_icon git)"
+  assert_contains "git},$git_icon," "$output"
+}
+
+# --- No user config file ---
+
+function test_format_no_user_config_uses_defaults() {
+  export TMUX_NERD_FONT_USER_CONFIG="/nonexistent/path/config.yml"
+  local output
+  output="$(generate_format)"
+  # Default show-name is true, so should end with #{pane_current_command}
+  local suffix
+  suffix="${output: -24}"
+  assert_equals " #{pane_current_command}" "$suffix"
+}

--- a/tmux-nerd-font-window-name.tmux
+++ b/tmux-nerd-font-window-name.tmux
@@ -2,7 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-plugin_format="#($CURRENT_DIR/bin/tmux-nerd-font-window-name #{pane_current_command} #{window_panes})"
+plugin_format="$("$CURRENT_DIR/bin/generate-tmux-format")"
 user_format="$(tmux show-option -gv automatic-rename-format 2>/dev/null)"
 placeholder="#{window_icon}"
 


### PR DESCRIPTION
For #9 

## Summary

This PR optimizes the tmux plugin's execution by generating the tmux format string once at load time, rather than executing a script for every window update.

## Changes

### New Files
- **bin/generate-tmux-format** (98 lines) - Generates the flat tmux format string using awk at load time
- **bin/lib.sh** (41 lines) - Extracted shared configuration parsing functions for reuse
- **test/generate_tmux_format_test.sh** (162 lines) - Comprehensive test suite for format generation

### Modified Files
- **bin/tmux-nerd-font-window-name** - Refactored to use shared lib.sh for config parsing
- **tmux-nerd-font-window-name.tmux** - Updated entry point to use pre-generated format string
- **Makefile** - Minor updates

## Benefits

- **Performance**: Avoids per-window script execution - format string is built once at tmux load
- **Maintainability**: Shared lib.sh reduces code duplication
- **Testability**: Dedicated test file for format generation logic

## Testing

All tests pass:
```
./lib/bashunit test/
```

## Backward Compatibility

No breaking changes - the plugin continues to work with the same configuration format.