### PR TITLE
Add Nix flake for nixpkgs installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Automatically add Nerd Font support to your tmux window names!
 
 ## Requirements
 
-The following dependencies are required in order to use this plugin:
-
 - [tmux](https://github.com/tmux/tmux)
-- [tpm](https://github.com/tmux-plugins/tpm)
+- A [Nerd Font](https://www.nerdfonts.com/) installed and configured in your terminal
 
-## Installation (via tpm)
+## Installation
+
+### tpm
 
 Add the following line to your tmux configuration file:
 
@@ -21,6 +21,47 @@ set -g @plugin 'joshmedeski/tmux-nerd-font-window-name'
 
 Run `<prefix>+I` to trigger the tpm installer which will download
 and source the plugin.
+
+### Nix (flakes)
+
+Add the flake input to your configuration:
+
+```nix
+{
+  inputs = {
+    tmux-nerd-font-window-name.url = "github:joshmedeski/tmux-nerd-font-window-name";
+  };
+}
+```
+
+Then use the plugin in your tmux configuration via Home Manager:
+
+```nix
+{ inputs, pkgs, ... }:
+
+{
+  programs.tmux = {
+    enable = true;
+    plugins = [
+      inputs.tmux-nerd-font-window-name.packages.${pkgs.system}.default
+    ];
+  };
+}
+```
+
+Or using the overlay:
+
+```nix
+{
+  nixpkgs.overlays = [
+    inputs.tmux-nerd-font-window-name.overlays.default
+  ];
+
+  programs.tmux.plugins = [
+    pkgs.tmuxPlugins.tmux-nerd-font-window-name
+  ];
+}
+```
 
 ## Configuration
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "tmux plugin to display Nerd Font icons for window names";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.tmuxPlugins.mkTmuxPlugin {
+            pluginName = "tmux-nerd-font-window-name";
+            version = "unstable-${self.shortRev or self.dirtyShortRev or "dev"}";
+            src = self;
+            rtpFilePath = "tmux-nerd-font-window-name.tmux";
+          };
+        }
+      );
+
+      overlays.default = final: prev: {
+        tmuxPlugins = prev.tmuxPlugins // {
+          tmux-nerd-font-window-name = self.packages.${final.system}.default;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with `mkTmuxPlugin` package and overlay for Nix users
- Update README with Nix installation instructions (Home Manager + overlay examples)
- Reorganize installation section to support both tpm and Nix

Closes #63

## Test plan

- [ ] Verify `nix flake check` passes
- [ ] Test installation via Home Manager `programs.tmux.plugins`
- [ ] Confirm plugin loads and icons render correctly from the Nix store