### PR TITLE
Add sem-version-icon config for version-number commands

### DIFF
--- a/bin/defaults.yml
+++ b/bin/defaults.yml
@@ -3,6 +3,7 @@ config:
   fallback-icon: "?"
   show-name: true
   always-show-fallback-name: false
+  sem-version-icon: "null"
 
 icons:
   alacritty: ""

--- a/bin/generate-tmux-format
+++ b/bin/generate-tmux-format
@@ -13,12 +13,13 @@ generate_format() {
   fi
 
   # Get config values
-  local fallback_icon show_name always_fallback icon_position multi_pane_icon
+  local fallback_icon show_name always_fallback icon_position multi_pane_icon sem_version_icon
   fallback_icon="$(get_config_value config fallback-icon "$user_config")"
   show_name="$(get_config_value config show-name "$user_config")"
   always_fallback="$(get_config_value config always-show-fallback-name "$user_config")"
   icon_position="$(get_config_value config icon-position "$user_config")"
   multi_pane_icon="$(get_config_value config multi-pane-icon "$user_config")"
+  sem_version_icon="$(get_config_value config sem-version-icon "$user_config")"
 
   # Build the flat tmux format string using awk
   # Reads icon mappings from both config files (user overrides defaults),
@@ -29,7 +30,8 @@ generate_format() {
     -v fallback="$fallback_icon" \
     -v show_name="$show_name" \
     -v always_fallback="$always_fallback" \
-    -v icon_pos="$icon_position" '
+    -v icon_pos="$icon_position" \
+    -v sem_ver_icon="$sem_version_icon" '
     /^[^ #]/ { current = $0; sub(/:.*/, "", current) }
     current == "icons" && /^  [^ #]/ {
       key = $0; sub(/:.*/, "", key); gsub(/^ +/, "", key)
@@ -67,9 +69,17 @@ generate_format() {
         chain = chain "#{?#{==:#{pane_current_command}," k "}," v ",}"
       }
 
-      # Append fallback wrapper: if chain evaluates to non-empty (a match),
+      # Build semver conditional if configured
+      sem_ver = ""
+      if (sem_ver_icon != "null" && sem_ver_icon != "") {
+        gsub(/#/, "##", sem_ver_icon)
+        sem_ver = "#{?#{m/r:^[0-9]+\\.[0-9]+(\\.[0-9]+)?$,#{pane_current_command}}," sem_ver_icon ",}"
+      }
+
+      # Append fallback wrapper: if chain or semver evaluates to non-empty (a match),
       # the fallback is suppressed; if empty (no match), fallback is shown
-      result = chain "#{?" chain ",," fb "}"
+      combined = chain sem_ver
+      result = combined "#{?" combined ",," fb "}"
 
       # Wrap with name display if show-name is enabled
       if (show_name == "true") {

--- a/bin/tmux-nerd-font-window-name
+++ b/bin/tmux-nerd-font-window-name
@@ -16,8 +16,14 @@ main() {
   # Fallback icon if no specific icon is found
   local is_fallback=false
   if [ "$icon" == "null" ] || [ -z "$icon" ]; then
-    icon="$(get_config_value config fallback-icon "$user_config")"
-    is_fallback=true
+    local sem_version_icon
+    sem_version_icon="$(get_config_value config sem-version-icon "$user_config")"
+    if [[ "$name" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] && [ "$sem_version_icon" != "null" ] && [ -n "$sem_version_icon" ]; then
+      icon="$sem_version_icon"
+    else
+      icon="$(get_config_value config fallback-icon "$user_config")"
+      is_fallback=true
+    fi
   fi
 
   # If multiple panes are open, add a multi-pane icon if available

--- a/test/fixtures/sem-version-show-name.yml
+++ b/test/fixtures/sem-version-show-name.yml
@@ -1,0 +1,5 @@
+config:
+  fallback-icon: "?"
+  show-name: true
+  icon-position: left
+  sem-version-icon: "V"

--- a/test/fixtures/sem-version.yml
+++ b/test/fixtures/sem-version.yml
@@ -1,0 +1,4 @@
+config:
+  fallback-icon: "?"
+  show-name: false
+  sem-version-icon: "V"

--- a/test/generate_tmux_format_test.sh
+++ b/test/generate_tmux_format_test.sh
@@ -151,6 +151,25 @@ function test_format_contains_git_icon() {
 
 # --- No user config file ---
 
+# --- Semantic version matching ---
+
+function test_format_contains_semver_regex_when_configured() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/sem-version.yml"
+  local output
+  output="$(generate_format)"
+  assert_contains "#{m/r:" "$output"
+  assert_contains ",V,}" "$output"
+}
+
+function test_format_no_semver_regex_when_not_configured() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  local output
+  output="$(generate_format)"
+  assert_not_contains "#{m/r:" "$output"
+}
+
+# --- No user config file ---
+
 function test_format_no_user_config_uses_defaults() {
   export TMUX_NERD_FONT_USER_CONFIG="/nonexistent/path/config.yml"
   local output

--- a/test/tmux_nerd_font_window_name_test.sh
+++ b/test/tmux_nerd_font_window_name_test.sh
@@ -138,3 +138,41 @@ function test_fallback_name_disabled_unknown_command_shows_only_fallback_icon() 
   (exit "$exit_code"); assert_successful_code
   assert_equals "?" "$output"
 }
+
+# --- Semantic version matching ---
+
+function test_semver_three_part_returns_sem_version_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/sem-version.yml"
+  output="$(main 2.1.23 1 2>&1)" && exit_code=$? || exit_code=$?
+  (exit "$exit_code"); assert_successful_code
+  assert_equals "V" "$output"
+}
+
+function test_semver_two_part_returns_sem_version_icon() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/sem-version.yml"
+  output="$(main 1.0 1 2>&1)" && exit_code=$? || exit_code=$?
+  (exit "$exit_code"); assert_successful_code
+  assert_equals "V" "$output"
+}
+
+function test_semver_not_matched_for_non_version() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/sem-version.yml"
+  output="$(main node 1 2>&1)" && exit_code=$? || exit_code=$?
+  (exit "$exit_code"); assert_successful_code
+  expected="$(get_default_icon node)"
+  assert_equals "$expected" "$output"
+}
+
+function test_semver_falls_to_fallback_when_not_configured() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml"
+  output="$(main 2.1.23 1 2>&1)" && exit_code=$? || exit_code=$?
+  (exit "$exit_code"); assert_successful_code
+  assert_equals "?" "$output"
+}
+
+function test_semver_with_show_name() {
+  export TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/sem-version-show-name.yml"
+  output="$(main 2.1.23 1 2>&1)" && exit_code=$? || exit_code=$?
+  (exit "$exit_code"); assert_successful_code
+  assert_equals "V 2.1.23" "$output"
+}


### PR DESCRIPTION
## Problem

Some tools (like Claude Code) show up in tmux as bare version numbers (e.g. `2.1.23`). Since there's no icon mapping for these, they fall through to the fallback icon with no way to distinguish them.

## Solution

A new `sem-version-icon` config key that pattern-matches semver-like command names (`X.Y` or `X.Y.Z`) and displays a configured icon.

- Added `sem-version-icon: "null"` to defaults (disabled, opt-in)
- Regex check (`^[0-9]+\.[0-9]+(\.[0-9]+)?$`) sits between exact icon lookup and fallback
- Updated both the runtime script and `generate-tmux-format` for the new config
- Added 7 tests covering matching, non-matching, fallback, and show-name integration

## Test plan

- [x] `make test` passes (36/36 tests, including 7 new)
- [ ] Manual: set `sem-version-icon` in user config, reload plugin, verify version-number commands display the icon