### PR TITLE
fix: strip comments in yaml

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -17,6 +17,7 @@ get_yaml_value() {
       if ($0 ~ "^  " key ":") {
         val = $0
         sub(/^[^:]*: */, "", val)
+        sub(/ (#.*)$/, "", val)
         gsub(/^["'\''"]|["'\''"]$/, "", val)
         print val
         found = 1

--- a/test/fixtures/fallback-name.yml
+++ b/test/fixtures/fallback-name.yml
@@ -1,4 +1,4 @@
 config:
-  fallback-icon: "?"
+  fallback-icon: "?" # comments should be stripped
   show-name: false
   always-show-fallback-name: true


### PR DESCRIPTION
I've had an issue where I would see comments from my config show up in window names.
This solves it by stripping away the comments in `get_yaml_value`.

Example of the issue:

<img width="2034" height="270" alt="image" src="https://github.com/user-attachments/assets/389f3213-6fcb-4cb0-92b8-f3522c96458d" />

What my config is:
```yaml
config:
  fallback-icon: "?" # show when no definition is found
  multi-pane-icon: "" # show when window has multiple panes (blank by default)
  show-name: true # show the window name with the icon (defaults to false)
  icon-position: "left" # show the icon to the "left" or "right" of the window name (defaults to left)

```