### PR TITLE
fix: avoid blank and "not ready" window names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ tmux-nerd-font-window-name is a tmux plugin (installed via tpm) that automatical
 
 The plugin has four components:
 
-1. **`tmux-nerd-font-window-name.tmux`** - Entry point loaded by tpm. Generates the config cache, then sets `automatic-rename-format`: a `#()` call to the main script when the config has regex sections (`names-regex`/`icons-regex`), otherwise the static format from `bin/generate-tmux-format`. Supports a `#{window_icon}` placeholder for custom formats (the original template is saved to the `@tmux-nerd-font-window-name-template` tmux option).
+1. **`tmux-nerd-font-window-name.tmux`** - Entry point loaded by tpm. Generates the config cache, then sets `automatic-rename-format` to a `#()` call to the main script, wrapped in a conditional that falls back to `#{pane_current_command}` while the job's output is unavailable — tmux runs `#()` jobs asynchronously, expanding to nothing until output arrives and to `<'<command>' not ready>` after one second, so without the fallback the window name flashes blank or shows tmux's placeholder text. Supports a `#{window_icon}` placeholder for custom formats (the original template is saved to the `@tmux-nerd-font-window-name-template` tmux option).
 
 2. **`bin/tmux-nerd-font-window-name`** - Main script, run by tmux on every rename. Takes `pane_current_command`, `window_panes`, `pane_pid`, `window_id` as arguments, resolves the icon/name, and outputs the formatted string.
 
@@ -44,13 +44,14 @@ Flat YAML parsed with awk (no `yq` dependency). Two-level cascade resolved **at 
 
 ## Testing
 
-Tests use [bashunit](https://bashunit.com). Test files: `tmux_nerd_font_window_name_test.sh` (end-to-end through `main()`, including regex scenarios), `lib_test.sh` (lib.sh helpers), `cache_config_test.sh` (cache generation/loading), `generate_tmux_format_test.sh` (static format).
+Tests use [bashunit](https://bashunit.com). Test files: `tmux_nerd_font_window_name_test.sh` (end-to-end through `main()`, including regex scenarios), `lib_test.sh` (lib.sh helpers), `cache_config_test.sh` (cache generation/loading), `generate_tmux_format_test.sh` (static format), `entry_point_test.sh` (the `automatic-rename-format` the `.tmux` file installs, via a fake `tmux` on `PATH`).
 
 Conventions and traps:
 
 - Each test sets `TMUX_NERD_FONT_USER_CONFIG` to a fixture YAML in `test/fixtures/`; the cache mismatch-regen makes this work without extra setup.
 - Any test file that sources `cache-config` (directly or via the main script) must `export XDG_CACHE_HOME="$(mktemp -d)"` **before** the `source` line, or tests write to the real user cache.
 - bashunit runs each test in a subshell: use `$BASHPID`, not `$$`, for the current test process — and capture it into a variable *before* any `$(...)` (inside a command substitution `BASHPID` is the substitution's own subshell).
+- `entry_point_test.sh` runs the entry point in a subshell with a stub `tmux` that records its arguments; it asserts on format structure, so it needs updating whenever the format's shape changes.
 - Regex tests spawn a real fake child process: `bash -c 'exec -a "npm run dev" sleep 5' &`.
 - Coverage numbers from bashunit are unreliable for sourced files — treat the coverage table as a file checklist, not a metric. `make test` (with coverage) is ~10x slower than `./lib/bashunit test/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thanks for your interest in contributing to tmux-nerd-font-window-name! Pull req
 
 ## Project Structure
 
-- `tmux-nerd-font-window-name.tmux` - Entry point loaded by tpm: generates the config cache and sets `automatic-rename-format`
+- `tmux-nerd-font-window-name.tmux` - Entry point loaded by tpm: generates the config cache and sets `automatic-rename-format` (with a `#{pane_current_command}` fallback while the `#()` job has no output yet)
 - `bin/tmux-nerd-font-window-name` - Main script that resolves icons on each rename
 - `bin/cache-config` - Generates a sourceable config cache at plugin load (`generate_cache`/`load_cache`), so no YAML is parsed at rename time
 - `bin/lib.sh` - Shared helpers: YAML parsing, `shquote`, child-process listing, cached regex matching

--- a/test/entry_point_test.sh
+++ b/test/entry_point_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRY_POINT="$PLUGIN_DIR/tmux-nerd-font-window-name.tmux"
+FIXTURES_DIR="$PLUGIN_DIR/test/fixtures"
+
+# Keep the config cache away from the user's real cache directory
+export XDG_CACHE_HOME="$(mktemp -d)"
+
+# Run the entry point against a fake tmux that records every call and reports
+# $FAKE_USER_FORMAT as the existing automatic-rename-format
+run_entry_point() {
+  local user_format="$1"
+  local pid="$BASHPID"
+  local stub_dir="$XDG_CACHE_HOME/stub-$pid"
+  mkdir -p "$stub_dir"
+  TMUX_CALLS="$XDG_CACHE_HOME/calls-$pid"
+  : >"$TMUX_CALLS"
+
+  cat >"$stub_dir/tmux" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TMUX_CALLS"
+if [ "$1 $2 $3" = "show-option -gv automatic-rename-format" ]; then
+  printf '%s\n' "$FAKE_USER_FORMAT"
+fi
+exit 0
+STUB
+  chmod +x "$stub_dir/tmux"
+
+  PATH="$stub_dir:$PATH" \
+    TMUX_CALLS="$TMUX_CALLS" \
+    FAKE_USER_FORMAT="$user_format" \
+    TMUX_NERD_FONT_USER_CONFIG="$FIXTURES_DIR/no-show-name.yml" \
+    bash "$ENTRY_POINT"
+}
+
+# The format the entry point handed to `tmux set-option -g automatic-rename-format`
+set_format() {
+  grep '^set-option -g automatic-rename-format ' "$TMUX_CALLS" |
+    tail -1 | sed 's|^set-option -g automatic-rename-format ||'
+}
+
+set_up() {
+  _ORIGINAL_PATH="$PATH"
+}
+
+tear_down() {
+  PATH="$_ORIGINAL_PATH"
+}
+
+# --- Async job fallback ---
+
+function test_format_falls_back_while_job_is_not_ready() {
+  run_entry_point ""
+  # tmux substitutes "<'<command>' not ready>" after one second of job runtime
+  assert_contains '#{?#{m:*not ready*,#(' "$(set_format)"
+}
+
+function test_format_falls_back_while_job_output_is_empty() {
+  run_entry_point ""
+  # A job with no output yet expands to nothing, which would blank the name
+  assert_contains ")},#{pane_current_command},#{?#(" "$(set_format)"
+}
+
+function test_format_ends_with_the_job_and_its_fallback() {
+  run_entry_point ""
+  assert_contains ",#{pane_current_command}}}" "$(set_format)"
+}
+
+# --- User template ---
+
+function test_user_template_keeps_the_fallback_around_the_job() {
+  run_entry_point "#{window_icon} #{b:pane_current_path}"
+  local format
+  format="$(set_format)"
+  assert_contains '#{?#{m:*not ready*,#(' "$format"
+  assert_contains ' #{b:pane_current_path}' "$format"
+}
+
+function test_user_template_is_saved_for_the_rename_self_heal() {
+  run_entry_point "#{window_icon} #{b:pane_current_path}"
+  assert_contains \
+    'set-option -g @tmux-nerd-font-window-name-template #{window_icon} #{b:pane_current_path}' \
+    "$(cat "$TMUX_CALLS")"
+}

--- a/tmux-nerd-font-window-name.tmux
+++ b/tmux-nerd-font-window-name.tmux
@@ -7,7 +7,14 @@ source "$CURRENT_DIR//bin/cache-config"
 user_config="${TMUX_NERD_FONT_USER_CONFIG:-$USER_CONFIG}"
 generate_cache "$user_config"
 
-plugin_format="#($CURRENT_DIR/bin/tmux-nerd-font-window-name '#{pane_current_command}' '#{window_panes}' '#{pane_pid}' '#{window_id}')"
+job="#($CURRENT_DIR/bin/tmux-nerd-font-window-name '#{pane_current_command}' '#{window_panes}' '#{pane_pid}' '#{window_id}')"
+
+# tmux runs '#()' jobs asynchronously: the format expands to nothing until the
+# job produces output, and to "<'<command>' not ready>" once the job has been
+# running for more than a second. Fall back to the raw command in both cases so
+# the window name is never blank or filled with tmux's placeholder text.
+plugin_format="#{?#{m:*not ready*,$job},#{pane_current_command},#{?$job,$job,#{pane_current_command}}}"
+
 user_format="$(tmux show-option -gv automatic-rename-format 2>/dev/null)"
 placeholder="#{window_icon}"
 


### PR DESCRIPTION
Follows up on [james1236's comment on #36](https://github.com/joshmedeski/tmux-nerd-font-window-name/issues/36#issuecomment-5347207942).

## Problem

tmux runs `#()` jobs asynchronously, so the `automatic-rename-format` job has two states where it leaks non-icon text into the window name ([`format_job_get`](https://github.com/tmux/tmux/blob/master/format.c)):

| Job state | Format expands to | Window name shows |
| --- | --- | --- |
| running < 1s, no output yet | `""` | blank |
| running > 1s, no output yet | `<'<command>' not ready>` | tmux's placeholder text |

## Fix

Wrap the job in a conditional that falls back to `#{pane_current_command}` in both cases:

```bash
plugin_format="#{?#{m:*not ready*,$job},#{pane_current_command},#{?$job,$job,#{pane_current_command}}}"
```

The linked comment's patch handled only the `not ready` case. Testing against tmux 3.7c showed the empty-output case is the one you actually hit in practice: the name goes blank on the first evaluation and *stays* blank, because tmux does not re-run the rename until the pane command changes again. Hence the nested condition.

Both `#()` occurrences are the same command string, so tmux keys them to a single cached job — no extra process spawning.

## Verification

- Isolated tmux 3.7c server (detached session + real pty client, rename re-triggered by sending keys): with a deliberately slow job the name shows the fallback command immediately instead of blank; loading the real plugin resolves icons as expected.
- New `test/entry_point_test.sh` — the entry point had no test coverage before. It puts a stub `tmux` on `PATH` that records every invocation, runs the `.tmux` file, and asserts on the installed `automatic-rename-format`: both fallback guards, the trailing fallback branch, and that `#{window_icon}` substitution inserts the *wrapped* format rather than the bare job.
- Mutation-checked: reverting to the bare `$job` fails 4 of the 5 new tests.
- Full suite: 70 tests, 99 assertions, all passing.

## Notes

- These are structural assertions on the format string, not behavioral tests of tmux's async job semantics — that part needs a real pty client and a pane-command change, which is not something I'd put in CI. Noted in `CLAUDE.md` so anyone reshaping the format knows to update the test.
- Also corrected a stale sentence in `CLAUDE.md`: it still claimed the entry point used `bin/generate-tmux-format`'s static format unless regex sections existed, but #68 made the `#()` job unconditional.
- Deliberately does **not** close #36 — that report turned out to be an un-updated plugin (v2.2.0-ish), not this bug.